### PR TITLE
fix(ci): 修改npm安装命令以兼容旧版本依赖

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 20
           cache: npm
       
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
       
       - name: Check formatting
         run: npm run format:check


### PR DESCRIPTION
- 在GitHub Actions的lint工作流中调整npm ci命令
- 增加了--legacy-peer-deps参数以解决依赖冲突问题
- 确保CI环境中依赖安装的稳定性和兼容性
- 保持格式检查步骤不变