### PR TITLE
feat: support custom OpenAI headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
     "BASE_URL": "https://api.deepseek.com",
     "API_KEY": "sk-..."
   },
+  "headers": {
+    "User-Agent": "Mozilla/5.0 ..."
+  },
   "thinkingEnabled": true,
   "reasoningEffort": "max"
 }

--- a/README_cn.md
+++ b/README_cn.md
@@ -13,6 +13,9 @@
     "BASE_URL": "https://api.deepseek.com",
     "API_KEY": "sk-..."
   },
+  "headers": {
+    "User-Agent": "Mozilla/5.0 ..."
+  },
   "thinkingEnabled": true,
   "reasoningEffort": "max"
 }

--- a/README_en.md
+++ b/README_en.md
@@ -13,6 +13,9 @@ Create `~/.deepcode/settings.json` with:
     "BASE_URL": "https://api.deepseek.com",
     "API_KEY": "sk-..."
   },
+  "headers": {
+    "User-Agent": "Mozilla/5.0 ..."
+  },
   "thinkingEnabled": true,
   "reasoningEffort": "max"
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -228,6 +228,9 @@ Persist state and notify the webview
     "BASE_URL": "https://api.deepseek.com",
     "MODEL": "deepseek-v4-pro"
   },
+  "headers": {
+    "User-Agent": "Mozilla/5.0 ..."
+  },
   "thinkingEnabled": true,
   "reasoningEffort": "max",
   "notify": "~/.deepcode/notify.sh"
@@ -241,6 +244,7 @@ Persist state and notify the webview
 | `env.API_KEY` | string | Yes | - | API key for the configured provider |
 | `env.BASE_URL` | string | No | `https://api.deepseek.com` | Base URL for a DeepSeek or other OpenAI-compatible endpoint |
 | `env.MODEL` | string | No | `deepseek-v4-pro` | Model identifier passed to `chat.completions.create()` |
+| `headers` | object | No | `{}` | Extra HTTP headers passed to the OpenAI-compatible SDK client, useful for providers that require custom headers such as `User-Agent` |
 | `thinkingEnabled` | boolean | No | `true` for `deepseek-v4-flash` and `deepseek-v4-pro`; otherwise `false` | Enables the optional `thinking` request field when set to `true` |
 | `reasoningEffort` | `"high"` or `"max"` | No | `"max"` | Controls DeepSeek thinking strength via `reasoning_effort` when thinking mode is enabled |
 | `notify` | string | No | - | Executable script path triggered when a task ends in `completed` or `failed`, with `DURATION` set to the elapsed seconds |

--- a/src/common/openai-client.ts
+++ b/src/common/openai-client.ts
@@ -51,7 +51,7 @@ export function createOpenAIClient(projectRoot: string = process.cwd()): {
     };
   }
 
-  const cacheKey = `${settings.apiKey}::${settings.baseURL}`;
+  const cacheKey = `${settings.apiKey}::${settings.baseURL}::${JSON.stringify(settings.headers)}`;
   if (cachedOpenAI && cachedOpenAIKey === cacheKey) {
     return {
       client: cachedOpenAI,
@@ -72,6 +72,7 @@ export function createOpenAIClient(projectRoot: string = process.cwd()): {
   cachedOpenAI = new OpenAI({
     apiKey: settings.apiKey,
     baseURL: settings.baseURL || undefined,
+    defaultHeaders: settings.headers,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fetch: (url: any, init: any) => undiciFetch(url, { ...init, dispatcher: keepAliveAgent }),
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -424,6 +424,7 @@ class DeepcodingViewProvider implements vscode.WebviewViewProvider {
     const client = new OpenAI({
       apiKey,
       baseURL: baseURL || undefined,
+      defaultHeaders: settings.headers,
     });
 
     return {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,7 @@ export type EnabledSkillsSettings = Record<string, boolean>;
 
 export type DeepcodingSettings = {
   env?: DeepcodingEnv;
+  headers?: Record<string, string | undefined>;
   model?: string;
   temperature?: number;
   thinkingEnabled?: boolean;
@@ -62,6 +63,7 @@ export type DeepcodingSettings = {
 
 export type ResolvedDeepcodingSettings = {
   env: Record<string, string>;
+  headers: Record<string, string>;
   apiKey?: string;
   baseURL: string;
   model: string;
@@ -230,6 +232,22 @@ function normalizeEnv(env: DeepcodingSettings["env"]): Record<string, string> {
   return result;
 }
 
+function normalizeHeaders(headers: unknown): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    const headerName = key.trim();
+    if (!headerName || typeof value !== "string") {
+      continue;
+    }
+    result[headerName] = value;
+  }
+  return result;
+}
+
 export function collectDeepcodeEnv(processEnv: SettingsProcessEnv = process.env): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(processEnv)) {
@@ -322,6 +340,10 @@ export function resolveSettingsSources(
     ...projectEnv,
     ...systemEnv,
   };
+  const headers = {
+    ...normalizeHeaders(userSettings?.headers),
+    ...normalizeHeaders(projectSettings?.headers),
+  };
 
   const model =
     trimString(systemEnv.MODEL) ||
@@ -380,6 +402,7 @@ export function resolveSettingsSources(
 
   return {
     env,
+    headers,
     apiKey: trimString(env.API_KEY) || undefined,
     baseURL: trimString(env.BASE_URL) || defaults.baseURL,
     model,

--- a/src/tests/settings-and-notify.test.ts
+++ b/src/tests/settings-and-notify.test.ts
@@ -191,6 +191,36 @@ test("resolveSettingsSources applies user, project, and DEEPCODE environment pre
   assert.equal(resolved.env.WEBHOOK, "system-webhook");
 });
 
+test("resolveSettingsSources merges headers with project precedence", () => {
+  const resolved = resolveSettingsSources(
+    {
+      headers: {
+        "User-Agent": "user-agent",
+        "X-User": "1",
+        "X-Ignore": undefined,
+      },
+    },
+    {
+      headers: {
+        "User-Agent": "project-agent",
+        "X-Project": "2",
+        "X-Number": 123 as never,
+      },
+    },
+    {
+      model: "default-model",
+      baseURL: "https://default.example.com",
+    },
+    TEST_PROCESS_ENV
+  );
+
+  assert.deepEqual(resolved.headers, {
+    "User-Agent": "project-agent",
+    "X-User": "1",
+    "X-Project": "2",
+  });
+});
+
 test("resolveSettingsSources merges permission settings", () => {
   const resolved = resolveSettingsSources(
     {


### PR DESCRIPTION
## 概述

本 PR 为 OpenAI 兼容接口新增可配置 HTTP Headers 的能力。

部分 NewAPI / 中转站部署在 WAF 或 Cloudflare 之后，可能会根据请求头拦截 SDK 默认请求，尤其是默认的 SDK `User-Agent`。本次改动允许用户直接在 `~/.deepcode/settings.json` 或 `./.deepcode/settings.json` 中配置额外 headers，例如自定义 `User-Agent`，无需修改扩展源码即可兼容这类中转站。

## 已完成的工作

1. ✅ **配置扩展**：新增顶层 `headers` 配置，并仅保留字符串类型的 header 值。
2. ✅ **客户端接入**：将配置中的 `headers` 传递给 OpenAI SDK 的 `defaultHeaders`。
3. ✅ **缓存修正**：将 `headers` 纳入共享客户端缓存 key，确保 headers 变更后会重新创建客户端。
4. ✅ **文档更新**：在 README 与 `docs/guide.md` 中补充 `headers` 配置示例和说明。
5. ✅ **测试覆盖**：新增 headers 合并优先级的单元测试。
6. ✅ **本地验证**：已执行相关测试、类型检查和打包验证。

## 配置示例

```json
{
  "env": {
    "MODEL": "deepseek-v4-pro",
    "BASE_URL": "https://example.com/v1",
    "API_KEY": "sk-..."
  },
  "headers": {
    "User-Agent": "Mozilla/5.0 ..."
  },
  "thinkingEnabled": true,
  "reasoningEffort": "max"
}
```

## 验证命令

```bash
npx tsx --test src/tests/settings-and-notify.test.ts
npm run typecheck
npm run bundle
```

## 说明

- 同时支持用户级配置和项目级配置。
- 项目级 `headers` 会覆盖用户级同名 header。
- 适用于需要自定义 `User-Agent` 或其他请求头的 OpenAI 兼容中转站。
- 改动保持最小化，避免影响现有配置逻辑。